### PR TITLE
Add Google login example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ InCrowd è la piattaforma di crowdfunding che mette al centro **le tue idee**. P
 - **Database:** MongoDB
 - **Linguaggi:** TypeScript
 
+## 🔐 Login con Google
+
+Per abilitare l'autenticazione con Google imposta la variabile d'ambiente `GOOGLE_CLIENT_ID` nel backend con l'ID OAuth 2.0 della tua applicazione.
+
+Nel frontend è stato aggiunto un esempio di pulsante "Sign in with Google" nella pagina di login. Al termine dell'autenticazione viene inviato l'`idToken` all'endpoint `/api/auth/google` esposto dal backend.
+
 
 ---
 > **InCrowd**: Dai forma alla tua città, un'idea alla volta. 🌟

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.14.1",
-        "multer": "^1.4.5-lts.2"
+        "multer": "^1.4.5-lts.2",
+        "google-auth-library": "^9.0.0"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.14.1",
-    "multer": "^1.4.5-lts.2"
+    "multer": "^1.4.5-lts.2",
+    "google-auth-library": "^9.0.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -2,6 +2,10 @@ import { Request, Response } from "express";
 import User from "../models/User";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
+import { OAuth2Client } from "google-auth-library";
+import crypto from "crypto";
+
+const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 const JWT_SECRET = process.env.JWT_SECRET || "supersegreto"; // usa dotenv in produzione
 
@@ -30,6 +34,54 @@ export const login = async (req: Request, res: Response): Promise<any> => {
     return res.json({ token, user });
   } catch (err) {
     return res.status(500).json({ message: "Errore del server", error: err });
+  }
+};
+
+export const loginWithGoogle = async (req: Request, res: Response): Promise<any> => {
+  const { idToken } = req.body;
+
+  try {
+    const ticket = await googleClient.verifyIdToken({
+      idToken,
+      audience: process.env.GOOGLE_CLIENT_ID,
+    });
+    const payload = ticket.getPayload();
+
+    if (!payload || !payload.email) {
+      return res.status(401).json({ message: "Token non valido" });
+    }
+
+    const email = payload.email;
+    let user = await User.findOne({ "credenziali.email": email });
+
+    if (!user) {
+      const randomPass = crypto.randomBytes(16).toString("hex");
+      const hashedPassword = await bcrypt.hash(randomPass, 10);
+
+      user = new User({
+        nome: payload.given_name || "",
+        cognome: payload.family_name || "",
+        biografia: "Google user",
+        fotoProfilo: {
+          data: "",
+          contentType: "",
+        },
+        credenziali: {
+          email,
+          password: hashedPassword,
+        },
+      });
+
+      await user.save();
+    }
+
+    const token = jwt.sign({ userId: user._id, email }, JWT_SECRET, {
+      expiresIn: "1h",
+    });
+
+    return res.json({ token, user });
+  } catch (err) {
+    return res.status(401).json({ message: "Token non valido", error: err });
   }
 };
 

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,8 +1,9 @@
 import { Router } from "express";
-import { login } from "../controllers/authController";
+import { login, loginWithGoogle } from "../controllers/authController";
 
 const router = Router();
 
 router.post("/login", login);
+router.post("/google", loginWithGoogle);
 
 export default router;

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare const google: any;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="app"></div>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -12,6 +12,12 @@
       </div>
       <button type="submit">Login</button>
     </form>
+    <div id="g_id_onload"
+         data-client_id="YOUR_GOOGLE_CLIENT_ID"
+         data-callback="handleCredentialResponse"
+         data-auto_prompt="false">
+    </div>
+    <div class="g_id_signin" data-type="standard"></div>
     <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
   </div>
 </template>
@@ -49,6 +55,23 @@ const login = async () => {
     errorMessage.value = err.response?.data?.message || 'Errore durante il login';
   }
 };
+
+// Gestione risposta Google
+const handleCredentialResponse = async (response: any) => {
+  try {
+    const res = await axios.post('http://localhost:3000/api/auth/google', {
+      idToken: response.credential,
+    });
+    userStore.setToken(res.data.token);
+    userStore.setUser(res.data.user);
+    router.push('/');
+  } catch (err: any) {
+    errorMessage.value = err.response?.data?.message || 'Errore durante il login con Google';
+  }
+};
+
+// Rende la funzione disponibile globalmente per lo script Google
+(window as any).handleCredentialResponse = handleCredentialResponse;
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add Google login API using google-auth-library
- expose `/api/auth/google` endpoint
- add Google sign-in example to the frontend login view
- document how to use Google login in the README

## Testing
- `git status --short`