### PR TITLE
New last comments feature for Operatori

### DIFF
--- a/backend/src/controllers/propostaController.ts
+++ b/backend/src/controllers/propostaController.ts
@@ -1,3 +1,19 @@
+// Restituisce gli ultimi commenti globali (tutte le proposte)
+export const getUltimiCommenti = async (req: Request, res: Response) => {
+  try {
+    const limit = parseInt(req.query.limit as string) || 10;
+    // Popola utente (nome) e proposta (titolo e _id)
+    const commenti = await Commento.find({})
+      .sort({ dataOra: -1 })
+      .limit(limit)
+      .populate('utente', 'nome')
+      .populate('proposta', 'titolo');
+    res.json(apiResponse({ data: { commenti }, message: 'Ultimi commenti' }));
+  } catch (err) {
+    console.error('Errore nel recupero ultimi commenti:', err);
+    res.status(500).json(apiResponse({ message: 'Errore nel recupero ultimi commenti', error: err }));
+  }
+};
 import { Request, Response } from "express";
 import { AuthenticatedRequest } from "../middleware/authMiddleware";
 import Proposta from "../models/Proposta";

--- a/backend/src/routes/propostaRoutes.ts
+++ b/backend/src/routes/propostaRoutes.ts
@@ -1,11 +1,13 @@
+
 import express from "express";
-import { getAllProposte, addProposta, hyperProposta, aggiungiCommento, getCommentiProposta, getPendingProposte, updateStatoProposta, deleteProposta, searchProposte, getMyProposte, getPropostaById, deleteCommento } from "../controllers/propostaController";
+import { getAllProposte, addProposta, hyperProposta, aggiungiCommento, getCommentiProposta, getPendingProposte, updateStatoProposta, deleteProposta, searchProposte, getMyProposte, getPropostaById, deleteCommento, getUltimiCommenti } from "../controllers/propostaController";
 import multer from "multer";
 import { authMiddleware, requireRole } from "../middleware/authMiddleware";
 
-
-
 const router = express.Router();
+
+// Rotta per ottenere gli ultimi commenti globali
+router.get("/commenti", getUltimiCommenti);
 
 // Configura Multer per caricare i file in memoria (memoria temporanea)
 const storage = multer.memoryStorage();

--- a/frontend/src/api/commentiApi.ts
+++ b/frontend/src/api/commentiApi.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { useUserStore } from '@/stores/userStore';
+
+export async function getUltimiCommenti(limit = 10) {
+  const userStore = useUserStore();
+  const token = userStore.token;
+  const res = await axios.get(
+    `${import.meta.env.VITE_BACKEND_URL}/api/proposte/commenti?limit=${limit}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data.data.commenti;
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -83,7 +83,12 @@ const routes = [
     path: '/:pathMatch(.*)*',
     name: 'notFound',
     component: NotFoundView
-  }
+  },
+  {
+  path: '/comments',
+  name: 'UltimiCommenti',
+  component: () => import('@/views/UltimiCommentiView.vue') 
+  },
 ]
 
 const router = createRouter({

--- a/frontend/src/views/PannelloOperatoreView.vue
+++ b/frontend/src/views/PannelloOperatoreView.vue
@@ -37,7 +37,10 @@ const goToUserManagement = () => {
   router.push('/users')
 }
 
-// Carica statistiche reali dal backend
+const goToCommentManagement = () => {
+  router.push('/comments')
+}
+
 onMounted(async () => {
   try {
     loading.value = true
@@ -51,6 +54,7 @@ onMounted(async () => {
     loading.value = false
   }
 })
+
 </script>
 
 <template>
@@ -170,6 +174,20 @@ onMounted(async () => {
             </div>
             <div class="action-footer">
               <span class="action-cta">Visualizza Utenti →</span>
+            </div>
+          </div>
+
+          <!-- Ultimi Commenti -->
+          <div class="action-card" @click="goToCommentManagement">
+            <div class="action-header">
+              <div class="action-icon">💬</div>
+            </div>
+            <div class="action-content">
+              <h3>Ultimi Commenti</h3>
+              <p>Visualizza gli ultimi commenti inseriti dagli utenti su tutte le proposte.</p>
+            </div>
+            <div class="action-footer">
+              <span class="action-cta">Visualizza Commenti →</span>
             </div>
           </div>
 

--- a/frontend/src/views/UltimiCommentiView.vue
+++ b/frontend/src/views/UltimiCommentiView.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { getUltimiCommenti } from '@/api/commentiApi'
+import { deleteCommento } from '@/api/propostaApi'
+import { useUserStore } from '@/stores/userStore'
+import { useModal } from '@/composables/useModal'
+const loading = ref(true)
+const error = ref('')
+const ultimiCommenti = ref<any[]>([])
+const userStore = useUserStore()
+const { showConfirm, showError } = useModal()
+
+async function eliminaCommento(commento: any) {
+  const conferma = await showConfirm('Elimina commento', 'Sei sicuro di voler eliminare questo commento?')
+  if (!conferma) return
+  try {
+    await deleteCommento(commento.proposta?._id, commento._id, userStore.token)
+    ultimiCommenti.value = ultimiCommenti.value.filter(c => c._id !== commento._id)
+  } catch (err: any) {
+    showError('Errore', err.message || 'Errore nella cancellazione del commento')
+  }
+}
+
+onMounted(async () => {
+  try {
+    loading.value = true
+    ultimiCommenti.value = await getUltimiCommenti(20)
+  } catch (err: any) {
+    error.value = err.message || 'Errore nel caricamento dei commenti'
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="comments-view">
+    <h1>Ultimi Commenti</h1>
+    <div v-if="loading" class="loading-section">
+      <div class="loading-spinner"></div>
+      <p>Caricamento commenti...</p>
+    </div>
+    <div v-else-if="error" class="error-section">
+      <div class="error-icon">⚠️</div>
+      <h3>Errore nel caricamento</h3>
+      <p>{{ error }}</p>
+    </div>
+    <div v-else>
+      <div v-if="ultimiCommenti.length === 0" class="empty-state">
+        <div class="empty-icon">💬</div>
+        <h3>Nessun commento trovato</h3>
+      </div>
+      <div v-else class="comments-list">
+        <div v-for="commento in ultimiCommenti" :key="commento._id" class="comment-card">
+          <div class="comment-proposta-title">
+            <strong>Proposta:</strong>
+            <template v-if="commento.proposta?._id">
+              <router-link
+                :to="`/proposte/${commento.proposta._id}`"
+                class="proposta-link"
+              >
+                {{ commento.proposta.titolo }}
+              </router-link>
+            </template>
+            <template v-else>
+              Sconosciuta
+            </template>
+          </div>
+          <div class="comment-content">{{ commento.contenuto }}</div>
+          <div class="comment-meta">
+            <span class="comment-user">di {{ commento.utente?.nome || 'Utente' }}</span>
+            <span class="comment-date">{{ new Date(commento.dataOra).toLocaleString('it-IT') }}</span>
+            <button class="delete-comment-btn" @click="eliminaCommento(commento)" title="Elimina commento">
+              🗑️Elimina commento
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.comments-view {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 1.2rem;
+  box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+}
+.comments-view h1 {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  color: #404149;
+}
+.comments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+.comment-card {
+  background: #f8f7f3;
+  border-radius: 0.8rem;
+  padding: 1.2rem 1rem;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.04);
+  position: relative;
+}
+.comment-proposta-title {
+  font-size: 1rem;
+  color: #fe4654;
+  margin-bottom: 0.5rem;
+}
+.comment-content {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+  color: #222;
+}
+.comment-meta {
+  font-size: 0.95rem;
+  color: #666;
+  display: flex;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+.delete-comment-btn {
+  background: none;
+  border-color: #fe4654;
+  border: none;
+  color: #fe4654;
+  font-size: 0.8rem;
+  cursor: pointer;
+  margin-left: auto;
+  padding: 0.3rem 0.6rem;
+  border-radius: 0.5rem;
+  transition: background 0.2s;
+  border: 1px solid;
+}
+.delete-comment-btn:hover {
+  background: #ffeaea;
+}
+.loading-section, .error-section, .empty-state {
+  text-align: center;
+  padding: 3rem 1.5rem;
+}
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #f0f0f0;
+  border-top: 3px solid #fe4654;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 1rem;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+.empty-icon {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+</style>
+
+<style scoped>
+.proposta-link {
+  color: #fe4654;
+  text-decoration: underline;
+  font-weight: 600;
+  transition: color 0.2s, transform 0.2s;
+  cursor: pointer;
+  display: inline-block;
+}
+.proposta-link:hover, .proposta-link:focus {
+  color: #b8001c;
+  transform: scale(1.04);
+  outline: none;
+  box-shadow: none;
+}
+
+.proposta-link:focus,
+.proposta-link:focus-visible,
+.proposta-link:active {
+  outline: none !important;
+  box-shadow: none !important;
+}
+</style>


### PR DESCRIPTION
This pull request introduces a new feature that allows operators to view and manage the latest comments made by users across all proposals. The changes span backend API additions, frontend API integration, UI enhancements, and routing updates to support this new functionality.

**Backend API Enhancements:**

* Added a new controller method `getUltimiCommenti` in `propostaController.ts` to fetch the most recent comments globally, including user and proposal details.
* Registered a new route `/commenti` in `propostaRoutes.ts` to expose the latest comments endpoint.

**Frontend API and Routing:**

* Implemented `getUltimiCommenti` in `commentiApi.ts` to retrieve recent comments from the backend, using authentication.
* Added a new route `/comments` and associated it with the `UltimiCommentiView.vue` component for displaying the comments page.

**User Interface Updates:**

* Created a new view `UltimiCommentiView.vue` that lists the latest comments, allows deletion, and provides links to the related proposals.
* Enhanced the operator dashboard (`PannelloOperatoreView.vue`) by adding a card to access the new "Ultimi Commenti" page and handling its navigation. [[1]](diffhunk://#diff-7353ff8870cad924ed054895353c8578edee3f3cc299d7cc20d09e1983d54783L40-R43) [[2]](diffhunk://#diff-7353ff8870cad924ed054895353c8578edee3f3cc299d7cc20d09e1983d54783R180-R193) [[3]](diffhunk://#diff-7353ff8870cad924ed054895353c8578edee3f3cc299d7cc20d09e1983d54783R57)