### PR TITLE
Refactor ente model to use 'nome' as organization name

### DIFF
--- a/backend/src/controllers/followController.ts
+++ b/backend/src/controllers/followController.ts
@@ -118,8 +118,8 @@ export const getFollowers = async (req: Request, res: Response) => {
     for (const follow of follows) {
       const followerInfo = await findUserOrEnte(follow.followerId.toString());
       if (followerInfo) {
-        // Normalizza i campi: per gli enti usa nome_org come nome visualizzato
-        const displayName = followerInfo.entity.nome || followerInfo.entity.nome_org || '';
+        // nome is now the organization name for enti
+        const displayName = followerInfo.entity.nome || '';
         const followerData = {
           _id: followerInfo.entity._id,
           nome: displayName,
@@ -155,8 +155,8 @@ export const getFollowing = async (req: Request, res: Response) => {
     for (const follow of follows) {
       const followingInfo = await findUserOrEnte(follow.followingId.toString());
       if (followingInfo) {
-        // Normalizza i campi: per gli enti usa nome_org come nome visualizzato
-        const displayName = followingInfo.entity.nome || followingInfo.entity.nome_org || '';
+        // nome is now the organization name for enti
+        const displayName = followingInfo.entity.nome || '';
         const followingData = {
           _id: followingInfo.entity._id,
           nome: displayName,

--- a/backend/src/models/Ente.ts
+++ b/backend/src/models/Ente.ts
@@ -3,8 +3,7 @@ import { allegatoSchema } from "./Allegato";
 import { credenzialiSchema } from "./Credenziali";
 
 const enteSchema = new mongoose.Schema({
-  nome_org: { type: String, required: true }, // Nome organizzazione per gli enti
-  nome: { type: String, required: false }, // Nome referente (opzionale)
+  nome: { type: String, required: true }, // Nome dell'ente/organizzazione
   codiceFiscale: { type: String, required: true},
   biografia: { type: String, required: false, default: ""},
   fotoProfilo: {type: allegatoSchema, required: false},

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -82,7 +82,7 @@ router.get("/", authMiddleware, requireRole('operatore'), getAllUsers);
  * - user_type: 'privato' | 'ente' (obbligatorio)
  * - nome: string (obbligatorio)
  * - cognome: string (obbligatorio per privati)
- * - nome_org: string (obbligatorio per enti)
+ * - nome: string (obbligatorio per enti, rappresenta il nome dell'organizzazione)
  * - codiceFiscale: string (obbligatorio)
  * - email: string (obbligatorio)
  * - password: string (obbligatorio)
@@ -96,7 +96,7 @@ router.post("/", upload.single("fotoProfilo"), handleMulterError, createUser);
 
 /**
  * GET /api/user/search
- * Cerca utenti per nome, cognome, nome_org o biografia
+ * Cerca utenti per nome, cognome o biografia
  * 
  * Query parameters:
  * - q: string (obbligatorio, min 2 caratteri) - Testo di ricerca
@@ -127,7 +127,7 @@ router.get("/me", authMiddleware, getCurrentUser);
  * Body richiesto (multipart/form-data):
  * - nome: string (opzionale)
  * - cognome: string (opzionale, solo per privati)
- * - nome_org: string (opzionale, solo per enti)
+ * - nome: string (opzionale, rappresenta il nome dell'organizzazione per enti)
  * - biografia: string (opzionale)
  * - fotoProfilo: file (opzionale, max 5MB)
  * 

--- a/backend/tests/__tests__/rf1.registrazione.test.js
+++ b/backend/tests/__tests__/rf1.registrazione.test.js
@@ -18,8 +18,7 @@ describe('RF1 - Registrazione', () => {
   test('Creazione ente con oauthCode (senza password)', async () => {
     const res = await makeRequest('POST', '/user', {
       user_type: 'ente',
-      nome_org: 'Comune Test',
-      nome: 'Comune',
+      nome: 'Comune Test', // nome is now the organization name
       codiceFiscale: 'RSSMRA85C03H501U',
       email: uniqueEmail(),
       oauthCode: 'fake-oauth-code'

--- a/frontend/src/api/userApi.ts
+++ b/frontend/src/api/userApi.ts
@@ -30,7 +30,7 @@ export interface CreateUserData {
   user_type: 'privato' | 'ente';
   nome: string;
   cognome?: string; // Obbligatorio per privati
-  nome_org?: string; // Obbligatorio per enti
+  // nome is now the organization name for enti
   codiceFiscale: string;
   biografia?: string;
   email: string;


### PR DESCRIPTION
Replaces all usage of 'nome_org' with 'nome' for ente (organization) entities across controllers, models, routes, and tests. Updates user creation, profile update, and search logic to treat 'nome' as the required and displayed organization name. Adjusts API documentation and test cases accordingly. Also adds support for Google profile photo import during registration.